### PR TITLE
Use latest versions of code quality gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,49 @@
 PATH
   remote: .
   specs:
-    clint_eastwood (0.0.1)
-      rails_best_practices (~> 1.15.4)
-      reek (~> 1.3.7)
-      rubocop (~> 0.23.0)
-      thor (~> 0.19.1)
+    clint_eastwood (0.0.2)
+      rails_best_practices (>= 1.15.4)
+      reek (>= 1.3.7)
+      rubocop (>= 0.28.0)
+      thor (>= 0.19.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.1.1)
-      i18n (~> 0.6, >= 0.6.9)
+    abstract_type (0.0.7)
+    activesupport (4.2.1)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    adamantium (0.2.0)
+      ice_nine (~> 0.11.0)
+      memoizable (~> 0.4.0)
     ast (2.0.0)
-    awesome_print (1.2.0)
+    astrolabe (1.3.0)
+      parser (>= 2.2.0.pre.3, < 3.0)
     code_analyzer (0.4.5)
       sexp_processor
     colored (1.2)
+    concord (0.1.5)
+      adamantium (~> 0.2.0)
+      equalizer (~> 0.0.9)
+    diff-lcs (1.2.5)
+    equalizer (0.0.11)
     erubis (2.7.0)
-    i18n (0.6.9)
-    json (1.8.1)
-    minitest (5.3.4)
-    parser (2.1.9)
+    i18n (0.7.0)
+    ice_nine (0.11.1)
+    json (1.8.3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    minitest (5.7.0)
+    parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
-      slop (~> 3.4, >= 3.4.5)
-    powerpack (0.0.9)
-    rails_best_practices (1.15.4)
+    powerpack (0.1.1)
+    procto (0.0.2)
+    rails_best_practices (1.15.7)
       activesupport
-      awesome_print
       code_analyzer (>= 0.4.3)
       colored
       erubis
@@ -41,30 +53,31 @@ GEM
       ruby-progressbar
     rainbow (2.0.0)
     rake (10.3.2)
-    reek (1.3.7)
-      rainbow
-      ruby2ruby (~> 2.0.8)
-      ruby_parser (~> 3.3)
-      sexp_processor
+    reek (2.2.1)
+      parser (~> 2.2)
+      rainbow (~> 2.0)
+      unparser (~> 0.2.2)
     require_all (1.3.2)
-    rubocop (0.23.0)
-      json (>= 1.7.7, < 2)
-      parser (~> 2.1.9)
-      powerpack (~> 0.0.6)
+    rubocop (0.31.0)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.1, < 3.0)
+      powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.5.1)
-    ruby2ruby (2.0.8)
-      ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
-    ruby_parser (3.6.1)
-      sexp_processor (~> 4.1)
-    sexp_processor (4.4.3)
-    slop (3.5.0)
+    ruby-progressbar (1.7.5)
+    sexp_processor (4.6.0)
     thor (0.19.1)
-    thread_safe (0.3.4)
-    tzinfo (1.2.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unparser (0.2.4)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2.5)
+      equalizer (~> 0.0.9)
+      parser (~> 2.2.2)
+      procto (~> 0.0.2)
 
 PLATFORMS
   ruby
@@ -73,3 +86,6 @@ DEPENDENCIES
   bundler (~> 1.6)
   clint_eastwood!
   rake
+
+BUNDLED WITH
+   1.10.2

--- a/clint_eastwood.gemspec
+++ b/clint_eastwood.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  
-  spec.add_dependency 'reek', '~> 1.3.7'
-  spec.add_dependency 'rubocop', '~> 0.28.0'
-  spec.add_dependency 'thor', '~> 0.19.1'
-  spec.add_dependency 'rails_best_practices', '~> 1.15.4'
+
+  spec.add_dependency 'reek', '>= 1.3.7'
+  spec.add_dependency 'rubocop', '>= 0.28.0'
+  spec.add_dependency 'thor', '>= 0.19.1'
+  spec.add_dependency 'rails_best_practices', '>= 1.15.4'
 
   spec.executables = ['clint']
 end

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,4 +1,7 @@
-EmptyLinesAroundBody:
+EmptyLinesAroundModuleBody:
+  Enabled: false
+
+EmptyLinesAroundClassBody:
   Enabled: false
 
 LineLength:


### PR DESCRIPTION
Update rubocop config to use current cop names for blank lines around
body tests.
